### PR TITLE
Improve support for Python class interface to PhenoPackets

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,56 @@
+## Using these examples in place
+
+To verify that the example works within the phenopacket-python directory:
+
+```
+cd phenopacket-python/
+source env/bin/activate # Or whatever equivalent is used to establish a Python environment
+cd examples/
+python gen_journal_packet.py
+
+```
+
+The output from `gen_journal_packet.py` should resemble:
+
+```
+{
+  "entities": [
+    {
+      "id": "http://monarchinitiative.org/patient/1",
+      "type": "patient"
+    },
+    {
+      "id": "http://monarchinitiative.org/patient/2",
+      "type": "patient"
+    }
+  ],
+  "id": "packet1",
+  "phenotype_profile": [
+    {
+      "entity": "http://monarchinitiative.org/patient/1",
+      "phenotype": {
+        "environment": {},
+        "offset": {},
+        "onset": {},
+        "severity": {}
+      }
+    }
+  ],
+  "title": "Fatal infantile mitochondrial encephalomyopathy, hypertrophic cardiomyopathy and optic atrophy associated with a homozygous OPA1 mutation"
+```
+
+
+## Using these examples from a different project or directory
+
+Until the `phenopacket-python` package is distributed via [PyPi](https://pypi.python.org/pypi), the easiest way to use the package is to install the repo locally and to adjust your `PYTHONPATH` environment variable to include the repo's directory. For example, suppose that the `phenopacket-python` repo is located in `~/phenopacket-python` and that you have a directory `~/phenopacket-example` where you want to build a test program. For this example, we will copy the `gen_journal_packet.py` example as our test program.
+
+
+```
+cd ~/phenopacket-python
+source env/bin/activate # Or whatever equivalent is used to establish a Python environment
+python setup.py install
+cd ~/phenopacket-example
+cp ~/phenopacket-python/examples/gen_journal_packet.py ./
+PYTHONPATH=$PYTHONPATH:~/phenopacket-python python gen_journal_packet.py
+```
+

--- a/examples/gen_journal_packet.py
+++ b/examples/gen_journal_packet.py
@@ -1,0 +1,57 @@
+from phenopacket.PhenoPacket import *
+from phenopacket.models.Meta import *
+import json
+
+def gen_journal_packet():
+
+    # We are going to build the PhenoPacket by constructing its terminal components
+    # and then composing them until we get our final packet.
+
+    # Add Entity(s)
+    patient_1 = Entity(
+                    id = "http://monarchinitiative.org/patient/1",
+                    type = EntityType.patient)
+                    # biological_sex = "female")
+
+    patient_2 = Entity(
+                    id = "http://monarchinitiative.org/patient/2",
+                    type = EntityType.patient)
+                    # biological_sex = "female")
+    phenopacket_entities = [patient_1, patient_2]
+
+
+    environment = Environment()
+    severity = ConditionSeverity()
+    onset = TemporalRegion()
+    offset = TemporalRegion()
+
+    # phenotype_1_1.onset = TemporalRegion()
+    # phenotype_1_1.onset.types = [OntologyClass()]
+    # phenotype_1_1.onset.types[0].id = "HP:0003593"
+    # phenotype_1_1.onset.types[0].label = "Infantile onset"
+
+    phenotype_1_1 = Phenotype(
+                        environment=environment,
+                        severity=severity,
+                        onset=onset,
+                        offset=offset)
+
+    phenotype_association_1_1 = PhenotypeAssociation(
+                                entity = patient_1.id,
+                                evidence_list = [],     # Sequence[Evidence]=[],
+                                # created = "!!date 2016 2 9"
+                                phenotype = phenotype_1_1)
+
+    phenotype_profile_1 = [phenotype_association_1_1]   # : Sequence[PhenotypeAssociation]=[]
+    phenopacket = PhenoPacket(
+                        packet_id = "packet1",
+                        title = "Fatal infantile mitochondrial encephalomyopathy, hypertrophic cardiomyopathy and optic atrophy associated with a homozygous OPA1 mutation",
+                        entities = phenopacket_entities,
+                        # schema = "journal-example-level-1",
+                        # '@context = "http://phenopacket.github.io/context/context.jsonld",
+                        phenotype_profile = phenotype_profile_1)
+
+    print(phenopacket)
+
+gen_journal_packet()
+

--- a/phenopacket/PhenoPacket.py
+++ b/phenopacket/PhenoPacket.py
@@ -3,7 +3,44 @@ from phenopacket.models.Environment import *
 from phenopacket.models.Condition import *
 from phenopacket.models.Genome import *
 from typing import Sequence
+import json
+import inspect
+from enum import Enum
 
+class CustomEncoder(json.JSONEncoder):
+    # def default(self, obj):
+    #     if hasattr(obj, 'to_json'):
+    #         return obj.to_json()
+    #     if isinstance(obj, Enum):
+    #         return obj.name
+    #     return json.JSONEncoder.default(self, obj)
+
+    def isempty(self, value):
+        return (hasattr(value, '__len__') and len(value) == 0)
+
+    def default(self, obj):
+        # if hasattr(obj, "to_json"):
+        #     return self.default(obj.to_json())
+        if isinstance(obj, Enum):
+            return obj.name
+        elif hasattr(obj, "__dict__"):
+            d = dict(
+                (key, value)
+                for key, value in inspect.getmembers(obj)
+                if not key.startswith("__")
+                and not inspect.isabstract(value)
+                and not inspect.isbuiltin(value)
+                and not inspect.isfunction(value)
+                and not inspect.isgenerator(value)
+                and not inspect.isgeneratorfunction(value)
+                and not inspect.ismethod(value)
+                and not inspect.ismethoddescriptor(value)
+                and not inspect.isroutine(value)
+                and not self.isempty(value)
+                and not value is None
+            )
+            return self.default(d)
+        return obj
 
 class PhenoPacket(object):
     """
@@ -26,3 +63,5 @@ class PhenoPacket(object):
         self.diagnosis_profile = diagnosis_profile
         self.environment_profile = environment_profile
 
+    def __str__(self):
+        return json.dumps(self, indent=2, sort_keys=True, cls=CustomEncoder)

--- a/phenopacket/models/Condition.py
+++ b/phenopacket/models/Condition.py
@@ -3,7 +3,7 @@ from phenopacket.models.Environment import Environment
 from phenopacket.models.Meta import Entity, Association, Evidence
 from phenopacket.models.Ontology import OntologyClass
 from typing import Sequence
-
+import json
 
 class Assay(ClassInstance):
     """
@@ -15,6 +15,28 @@ class Assay(ClassInstance):
                  negated_types: Sequence[OntologyClass]=[],
                  description: str=None) -> None:
         super().__init__(types, negated_types, description)
+
+
+
+class TemporalRegion(ClassInstance):
+
+    def __init__(self, types: Sequence[OntologyClass]=[],
+                 negated_types: Sequence[OntologyClass]=[],
+                 description: str=None,
+                 start_time: str=None, end_time: str=None) -> None:
+        super().__init__(types, negated_types, description)
+
+        self.start_time = start_time
+        self.end_time = end_time
+
+
+class ConditionSeverity(ClassInstance):
+
+    def __init__(self, types: Sequence[OntologyClass]=[],
+                 negated_types: Sequence[OntologyClass]=[],
+                 description: str=None) -> None:
+        super().__init__(types, negated_types, description)
+
 
 
 class Condition(ClassInstance):
@@ -47,14 +69,6 @@ class Condition(ClassInstance):
         self.offset = offset
         self.severity = severity
         self.environment = environment
-
-
-class ConditionSeverity(ClassInstance):
-
-    def __init__(self, types: Sequence[OntologyClass]=[],
-                 negated_types: Sequence[OntologyClass]=[],
-                 description: str=None) -> None:
-        super().__init__(types, negated_types, description)
 
 
 class DiseaseStage(Condition):
@@ -149,6 +163,10 @@ class Phenotype(Condition):
 
         self.measurements = measurements
 
+    def to_json(self):
+        return self.__dict__
+
+
 
 class PhenotypeAssociation(Association):
 
@@ -161,14 +179,7 @@ class PhenotypeAssociation(Association):
 
         self.phenotype = phenotype
 
+    def to_json(self):
+        return self.__dict__
 
-class TemporalRegion(ClassInstance):
 
-    def __init__(self, types: Sequence[OntologyClass]=[],
-                 negated_types: Sequence[OntologyClass]=[],
-                 description: str=None,
-                 start_time: str=None, end_time: str=None) -> None:
-        super().__init__(types, negated_types, description)
-
-        self.start_time = start_time
-        self.end_time = end_time

--- a/phenopacket/models/Meta.py
+++ b/phenopacket/models/Meta.py
@@ -1,6 +1,15 @@
 from phenopacket.models.Ontology import ClassInstance, OntologyClass
 from enum import Enum
 from typing import Sequence, List
+import json
+
+class EntityType(Enum):
+    disease = 0
+    organism = 1
+    patient = 2
+    variant = 3
+    genotype = 4
+    paper = 5
 
 
 class Entity(ClassInstance):
@@ -10,38 +19,27 @@ class Entity(ClassInstance):
     """
 
     # Could also make a class if we need to expose to other classes
-    EntityType = Enum('EntityType', 'disease organism patient variant genotype')
+    # EntityType = Enum('EntityType', 'disease organism patient variant genotype paper')
 
     def __init__(self, types: Sequence[OntologyClass]=[],
                  negated_types: Sequence[OntologyClass]=[],
-                 description: str=None, entity_id: str=None,
-                 entity_label: str=None, entity_type: str=None) -> None:
+                 description: str=None, id: str=None,
+                 label: str=None, type: str=None) -> None:
 
-        if entity_id is not None:
-            if not isinstance(entity_type, self.EntityType):
+        if id is not None:
+            if not isinstance(type, EntityType):
                 raise TypeError("type is not one of valid"
                                 " entity types {0}"
-                                .format(list(self.EntityType)))
+                                .format(list(EntityType)))
 
         super().__init__(types, negated_types, description)
-        self.id = entity_id
-        self.label = entity_label
-        self.entity_type = entity_type
+        self.id = id
+        self.label = label
+        self.type = type
 
+    def to_json(self):
+        return self.__dict__
 
-class Association(object):
-    """
-    An association connects an entity (for example, disease,
-    person or variant) with either another entity, or with
-    some kind of descriptor (for example, phenotype).
-
-    All pieces of evidences are attached to associations
-    """
-
-    def __init__(self, entity: Entity=None,
-                 evidence_list: Sequence[Evidence]=[]) -> None:
-        self.entity = entity
-        self.evidence_list = evidence_list
 
 
 class Evidence(ClassInstance):
@@ -60,10 +58,23 @@ class Evidence(ClassInstance):
         self.source = source
 
 
+class Association(object):
+    """
+    An association connects an entity (for example, disease,
+    person or variant) with either another entity, or with
+    some kind of descriptor (for example, phenotype).
+
+    All pieces of evidences are attached to associations
+    """
+
+    def __init__(self, entity: Entity=None,
+                 evidence_list: Sequence[Evidence]=[]) -> None:
+        self.entity = entity
+        self.evidence_list = evidence_list
+
+
 class Publication(object):
 
     def __init__(self, pub_id: str=None, title: str=None) -> None:
         self.id = pub_id
         self.title = title
-
-

--- a/phenopacket/models/Ontology.py
+++ b/phenopacket/models/Ontology.py
@@ -1,4 +1,15 @@
 from typing import Sequence
+import json
+
+
+class OntologyClass(object):
+
+    def __init__(self, class_id: str=None, label: str=None) -> None:
+        self.id = class_id
+        self.label = label
+
+    def to_json(self):
+        return self.__dict__
 
 
 class ClassInstance(object):
@@ -14,12 +25,8 @@ class ClassInstance(object):
         self.negated_types = negated_types
         self.description = description
 
-
-class OntologyClass(object):
-
-    def __init__(self, class_id: str=None, label: str=None) -> None:
-        self.id = class_id
-        self.label = label
+    def to_json(self):
+        return self.__dict__
 
 
 class PropertyValue(object):
@@ -28,5 +35,8 @@ class PropertyValue(object):
         # Filler can be an object or string
         self.property = prop
         self.filler = filler
+
+    def to_json(self):
+        return self.__dict__
 
 

--- a/tests/resources/schemas/phenopacket-level-1-schema.json
+++ b/tests/resources/schemas/phenopacket-level-1-schema.json
@@ -16,7 +16,7 @@
         "properties" : {
           "type" : {
             "type" : "string",
-            "enum" : [ "disease", "organism", "patient", "variant", "genotype" ]
+            "enum" : [ "disease", "organism", "patient", "variant", "genotype", "paper" ]
           },
           "types" : {
             "type" : "array",

--- a/tests/unit/json_object_test.py
+++ b/tests/unit/json_object_test.py
@@ -73,7 +73,7 @@ class JsonToObjectTestCase(unittest.TestCase):
         self.assertEqual(variant[0].phenotype.type._value['id'], 'HP:0003560')
         self.assertEqual(variant[0].phenotype.type._value['label'], 'Muscular dystrophy')
 
-    def test_rountrip_json(self):
+    def test_roundtrip_json(self):
         pheno_packet = self.namespace\
             .UrnJsonschemaOrgMonarchinitiativePpkModelPhenopacket()\
             .from_json(json.dumps(self.omim_example))

--- a/tests/unit/json_object_write_test.py
+++ b/tests/unit/json_object_write_test.py
@@ -1,0 +1,97 @@
+import unittest
+import os
+import json
+import python_jsonschema_objects as jsonobjects
+import inspect
+import pprint
+pp = pprint.PrettyPrinter(indent=4)
+
+from phenopacket.PhenoPacket import *
+from phenopacket.models.Meta import *
+
+class JsonToObjectTestCase(unittest.TestCase):
+    """
+    Test JSON to Python Object Mappers such as warlock and
+    python_jsonschema_objects, see
+    http://stackoverflow.com/questions/12465588/convert-a-json-schema-to-a-python-class
+    """
+
+    def setUp(self):
+        schema_path = "../resources/schemas/phenopacket-level-1-schema.json"
+        journal_path = "../resources/examples/journal-example-l2.json"
+
+        schema_fh = open(os.path.join(os.path.dirname(__file__), schema_path), 'r')
+        self.schema = json.load(schema_fh)
+
+        journal_fh = open(os.path.join(os.path.dirname(__file__), journal_path), 'r')
+        self.journal_example = json.load(journal_fh)
+
+        builder = jsonobjects.ObjectBuilder(self.schema)
+        self.namespace = builder.build_classes()
+
+        schema_fh.close()
+        journal_fh.close()
+
+    def tearDown(self):
+        pass
+
+    def test_journal_generation(self):
+
+        reference_pheno_packet = self.namespace\
+            .UrnJsonschemaOrgMonarchinitiativePpkModelPhenopacket()\
+            .from_json(json.dumps(self.journal_example))
+
+        # We are going to build the PhenoPacket by constructing its terminal components
+        # and then composing them until we get our final packet.
+
+        # Add Entity(s)
+        patient_1 = Entity(
+                        id = "http://monarchinitiative.org/patient/1",
+                        type = EntityType.patient)
+                        # biological_sex = "female")
+
+        patient_2 = Entity(
+                        id = "http://monarchinitiative.org/patient/2",
+                        type = EntityType.patient)
+                        # biological_sex = "female")
+        phenopacket_entities = [patient_1, patient_2]
+
+
+        environment = Environment()
+        severity = ConditionSeverity()
+        onset = TemporalRegion()
+        offset = TemporalRegion()
+
+        # phenotype_1_1.onset = TemporalRegion()
+        # phenotype_1_1.onset.types = [OntologyClass()]
+        # phenotype_1_1.onset.types[0].id = "HP:0003593"
+        # phenotype_1_1.onset.types[0].label = "Infantile onset"
+
+        phenotype_1_1 = Phenotype(
+                            environment=environment,
+                            severity=severity,
+                            onset=onset,
+                            offset=offset)
+
+        phenotype_association_1_1 = PhenotypeAssociation(
+                                    entity = patient_1.id,
+                                    evidence_list = [],     # Sequence[Evidence]=[],
+                                    # created = "!!date 2016 2 9"
+                                    phenotype = phenotype_1_1)
+
+        phenotype_profile_1 = [phenotype_association_1_1]   # : Sequence[PhenotypeAssociation]=[]
+        phenopacket = PhenoPacket(
+                            packet_id = "packet1",
+                            title = "Fatal infantile mitochondrial encephalomyopathy, hypertrophic cardiomyopathy and optic atrophy associated with a homozygous OPA1 mutation",
+                            entities = phenopacket_entities,
+                            # schema = "journal-example-level-1",
+                            # '@context = "http://phenopacket.github.io/context/context.jsonld",
+                            phenotype_profile = phenotype_profile_1)
+
+        print(phenopacket)
+
+        self.assertEqual(reference_pheno_packet.entities[0].id, reference_pheno_packet.entities[0].id)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#### Background

The phenopacket-python project appears to have been paused/interrupted before it could be completed. There are Python classes to represent the components of a PhenoPacket, but the unit tests are not exercising these fully, and there are inconsistencies between the unit test JSON schema and the Python classes.

Satwik and the phenopacket-scraper project are written in Python and we planned on the phenopacket-python package being available for the scraper project. This PR is an attempt to build out and document the Python Class API to PhenoPacket. It is not currently sufficient to meet our needs for `phenopacket-scraper`, but it will let Satwik and us figure out if there are any issues with the library or its packaging.
